### PR TITLE
Fix mistype in ssisTools.psm1

### DIFF
--- a/ssisTools.psm1
+++ b/ssisTools.psm1
@@ -81,7 +81,7 @@ function Start-DbaSsisDeploy
     if (!$ssisFolder)
     {
         Write-Host "Creating Folder ..."
-        $folder = New-Object "$ISNamespace.CatalogFolder" ($ssisCatalog, $Folder, $Folder)            
+        $folder = New-Object "$SSISNamespace.CatalogFolder" ($ssisCatalog, $Folder, $Folder)            
         $folder.Create()  
     }
 


### PR DESCRIPTION
Deployment module fails due to mistyped $SSISNamespace variable