### PR TITLE
Fix mistype in Start-DbaSsisDeploy.ps1

### DIFF
--- a/Start-DbaSsisDeploy.ps1
+++ b/Start-DbaSsisDeploy.ps1
@@ -52,7 +52,7 @@ function Start-DbaSsisDeploy
     if (!$ssisFolder)
     {
         Write-Host "Creating Folder ..."
-        $folder = New-Object "$ISNamespace.CatalogFolder" ($ssisCatalog, $Folder, $Folder)            
+        $folder = New-Object "$SSISNamespace.CatalogFolder" ($ssisCatalog, $Folder, $Folder)            
         $folder.Create()  
     }
 


### PR DESCRIPTION
Deployment fails due to misspelled variable $SSISNamespace